### PR TITLE
Fixed file dropzone on chrome based browsers

### DIFF
--- a/src/webFileSharingSystem.Web/Client/src/app/Components/file-upload/directive/dnd.directive.ts
+++ b/src/webFileSharingSystem.Web/Client/src/app/Components/file-upload/directive/dnd.directive.ts
@@ -77,8 +77,10 @@ export class DndDirective {
   }
 
   private async getFile(fileEntry: any): Promise<File> {
-    return await new Promise((resolve, reject) =>
-      fileEntry.file(resolve, reject)
-    );
+    const file: File = await new Promise((resolve, reject) =>
+      fileEntry.file(resolve, reject));
+    Object.defineProperty(file, 'webkitRelativePath', {
+      value: fileEntry.fullPath})
+    return file;
   }
 }

--- a/src/webFileSharingSystem.Web/Client/src/app/services/file-uploader.service.ts
+++ b/src/webFileSharingSystem.Web/Client/src/app/services/file-uploader.service.ts
@@ -230,6 +230,7 @@ export class FileUploaderService {
   }
 
   ensureDirectoryExists(path: string, parentId: number | null) {
+    if(path.charAt(0) == '/') path = path.slice(1);
     let folders = path.split("/").slice(0, -1);
     if (folders.length <= 0) return of(null);
     return this.http.post<number | null>(`${environment.apiUrl}/Upload/EnsureDirectory`, {parentId, folders});


### PR DESCRIPTION
Fixed bug where sending files via dropzone on Chrome-based browsers, files did not keep their folder structures and were uploaded to the root location